### PR TITLE
Skapade 9 wiki sidor/filer

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,25 @@
 <!-- 
     BJERREDS SALTSJÖBAD - BILDCOLLAGE
     =================================
+    
+    ╔════════════════════════════════════════════════════════════════════╗
+    ║  VIKTIGT: CHECKLISTA VID NY VERSION                                ║
+    ╠════════════════════════════════════════════════════════════════════╣
+    ║  1. Utveckla i "utveckling" branch (ALDRIG direkt i main!)         ║
+    ║  2. Commita och pusha till GitHub                                  ║
+    ║  3. Skapa Pull Request och merga till main                         ║
+    ║  4. Skapa tag: git tag -a vX.X -m "Version X.X: Beskrivning"       ║
+    ║  5. Pusha tag: git push origin vX.X                                ║
+    ║  6. SKAPA BACKUP-MAPP: mkdir vX.X                                  ║
+    ║     → git show vX.X:index.html | Out-File -Encoding utf8 vX.X/...  ║
+    ║     → Gör samma för styles.css och javaScript.js                   ║
+    ║  7. Commita och pusha backup-mappen                                ║
+    ║  8. Skapa Release på GitHub                                        ║
+    ║                                                                    ║
+    ║  OBS! Skapa ALLTID backup-mapp (vX.X/) samtidigt som ny version!   ║
+    ║  Detta gör det lätt att länka till och visa historiska versioner.  ║
+    ╚════════════════════════════════════════════════════════════════════╝
+    
     UPPDATERING 2026-01-03 (v1.0):
     - Ändrat CSS och JS-länkar till relativa sökvägar
     - Lagt till video-sektion med inbäddad Twitter-video
@@ -20,11 +39,18 @@
     - Lagt till versionsbadge som hämtar senaste version från GitHub API
     - Visar versionsnummer och release-datum automatiskt
     
-    UPPDATERING 2026-01-04 (v2.4 - förberedelse):
+    UPPDATERING 2026-01-04 (v2.4):
     - Lagt till versioner.html med komplett Git/GitHub dokumentation
     - Lagt till "Versioner & Git-guide" knapp
-    - Skapat versionsmappar /v1.0/ och /v2.0/ för historiska versioner
+    - Skapat versionsmappar /v1.0/, /v2.0/ och /v2.2/ för historiska versioner
     - Dokumenterat GitHub Pages och hur versioner hanteras
+    
+    UPPDATERING 2026-01-04 (v2.5):
+    - Skapat GitHub Wiki med 9 dokumentationssidor
+    - Wiki-sidor: Home, Bildhantering, localStorage, X API, Git Grunderna,
+      Arbetsflöde med branches, Tags och Releases, GitHub Pages, Lightbox
+    - Följt nytt arbetsflöde: utveckling branch → PR → merge → tag
+    - BACKUP-MAPP: /v2.5/ skapad efter merge
 -->
 <html lang="sv">
 <head>

--- a/wiki/Arbetsflöde-med-branches.md
+++ b/wiki/Arbetsflöde-med-branches.md
@@ -1,0 +1,192 @@
+# 🌿 Arbetsflöde med branches
+
+Denna sida beskriver **Feature Branch Workflow** - det rekommenderade sättet att arbeta med Git.
+
+---
+
+## Varför använda branches?
+
+En **branch** är en isolerad "kopia" av koden där du kan göra ändringar utan att påverka huvudkoden (`main`).
+
+```
+main     ─────●─────●─────●─────●─────●─────►
+              │           ▲
+              │           │ merge
+              ▼           │
+feature       └─────●─────●
+```
+
+### Fördelar
+
+| Fördel | Förklaring |
+|--------|------------|
+| 🛡️ Säkerhet | Produktionskoden i `main` förblir stabil |
+| 🧪 Testning | Testa ändringar innan de går live |
+| 👥 Granskning | Pull Requests möjliggör code review |
+| 📝 Dokumentation | PR-beskrivningar dokumenterar ändringar |
+| ↩️ Enkel ångra | Bara ta bort branchen om det inte fungerar |
+
+---
+
+## Feature Branch Workflow
+
+### Det kompletta arbetsflödet
+
+```bash
+# ════════════════════════════════════════════════════
+# STEG 1: ALLTID börja med att skapa utvecklingsbranch
+# ════════════════════════════════════════════════════
+git switch -c utveckling
+
+# ════════════════════════════════════════════════════
+# STEG 2: Gör ändringar och testa lokalt
+# ════════════════════════════════════════════════════
+# ... redigera filer ...
+git add .
+git commit -m "Beskrivning av ändring"
+
+# ════════════════════════════════════════════════════
+# STEG 3: Pusha utvecklingsbranchen till GitHub
+# ════════════════════════════════════════════════════
+git push origin utveckling
+
+# ════════════════════════════════════════════════════
+# STEG 4: Skapa Pull Request på GitHub
+# ════════════════════════════════════════════════════
+# → Gå till github.com/lundgren9/Twitter/pulls
+# → Klicka "New pull request"
+# → Välj "compare: utveckling" → "base: main"
+# → Skriv beskrivning
+
+# ════════════════════════════════════════════════════
+# STEG 5: Efter godkännande - merga till main
+# ════════════════════════════════════════════════════
+git switch main
+git pull origin main    # Hämta ev. ändringar
+git merge utveckling
+git push origin main
+
+# ════════════════════════════════════════════════════
+# STEG 6: Skapa version/tag
+# ════════════════════════════════════════════════════
+git tag -a v2.5 -m "Version 2.5: Beskrivning"
+git push origin v2.5
+
+# ════════════════════════════════════════════════════
+# STEG 7: Städa upp (ta bort utvecklingsbranch)
+# ════════════════════════════════════════════════════
+git branch -d utveckling              # Lokalt
+git push origin --delete utveckling   # Remote
+```
+
+---
+
+## git switch vs git checkout
+
+### Rekommendation: Använd `git switch`
+
+| Åtgärd | Gammalt | Nytt (rekommenderat) |
+|--------|---------|---------------------|
+| Byta branch | `git checkout main` | `git switch main` |
+| Skapa + byta | `git checkout -b ny` | `git switch -c ny` |
+| Återställa fil | `git checkout -- fil` | `git restore fil` |
+
+### Varför?
+`git checkout` gör **för många olika saker** (byta branch, återställa filer, checka ut tags). Det är lätt att göra fel.
+
+`git switch` gör **en sak** - byter branch. Säkrare och tydligare!
+
+Se mer: [[Tags och Releases#git-checkout-vs-git-switch]]
+
+---
+
+## Visualisering
+
+### Typiskt arbetsflöde
+
+```
+main         ─────●─────────────────●─────●─────►
+                  │                 ▲
+              switch -c         merge│
+                  ▼                 │
+utveckling        └─────●─────●─────┘
+                       add   commit
+                             push
+```
+
+### Flera features parallellt
+
+```
+main         ─────●───────────────●─────●───────●─────►
+                  │               ▲     │       ▲
+                  │               │     │       │
+feature-1         └─────●─────●───┘     │       │
+                                        │       │
+feature-2         ─────────────────●────┴───────┘
+```
+
+---
+
+## Branch-namnkonventioner
+
+| Prefix | Användning | Exempel |
+|--------|------------|---------|
+| `feature/` | Nya funktioner | `feature/lightbox` |
+| `fix/` | Buggfixar | `fix/image-rotation` |
+| `docs/` | Dokumentation | `docs/readme-update` |
+| `refactor/` | Kodförbättring | `refactor/cleanup` |
+| `utveckling` | Generell utveckling | `utveckling` |
+
+---
+
+## Vanliga kommandon
+
+```bash
+# Visa alla branches
+git branch -a
+
+# Skapa ny branch
+git switch -c ny-branch
+
+# Byta till befintlig branch
+git switch main
+
+# Se vilken branch du är på
+git branch
+
+# Ta bort lokal branch
+git branch -d branch-namn
+
+# Ta bort remote branch
+git push origin --delete branch-namn
+```
+
+---
+
+## Skydda main-branchen (GitHub)
+
+För att förhindra att någon pushar direkt till `main`:
+
+1. Gå till **Settings → Branches**
+2. Klicka **Add rule**
+3. Skriv `main` som branch name pattern
+4. Aktivera:
+   - ✅ Require a pull request before merging
+   - ✅ Require approvals (om flera utvecklare)
+
+---
+
+## Relaterade sidor
+
+- [[Git Grunderna]] - Introduktion till Git
+- [[Tags och Releases]] - Versionshantering
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [GitHub Flow](https://docs.github.com/en/get-started/quickstart/github-flow) - GitHub's officiella guide
+- [Atlassian: Feature Branch Workflow](https://www.atlassian.com/git/tutorials/comparing-workflows/feature-branch-workflow) - Detaljerad förklaring
+- [GitFlow vs GitHub Flow](https://www.gitkraken.com/learn/git/git-flow) - Jämförelse av arbetsflöden
+

--- a/wiki/Bildhantering.md
+++ b/wiki/Bildhantering.md
@@ -1,0 +1,157 @@
+# 🖼️ Bildhantering
+
+Denna sida förklarar hur bildcollaget och bildrotationen fungerar i applikationen.
+
+---
+
+## Översikt
+
+Bildcollaget visar **9 bilder** samtidigt i ett 3x3 grid. Var 5:e sekund byts en slumpmässig bild ut mot en ny från bildpoolen.
+
+```
+┌─────────┬─────────┬─────────┐
+│  Bild 1 │  Bild 2 │  Bild 3 │
+├─────────┼─────────┼─────────┤
+│  Bild 4 │  Bild 5 │  Bild 6 │
+├─────────┼─────────┼─────────┤
+│  Bild 7 │  Bild 8 │  Bild 9 │
+└─────────┴─────────┴─────────┘
+         ↓ var 5:e sekund
+    En slumpmässig bild byts ut
+```
+
+---
+
+## Bildpoolen
+
+### Standardbilder
+Applikationen kommer med **16 fördefinierade bilder** från Twitter/X:
+
+```javascript
+const defaultImages = [
+    'https://pbs.twimg.com/media/G6SRdvUW0AEJc6G?format=jpg&name=large',
+    'https://pbs.twimg.com/media/G6SRdxlWsAAPoIi?format=jpg&name=large',
+    // ... fler bilder
+];
+```
+
+### Användarbilder
+Användare kan lägga till egna bilder via input-fältet. Dessa sparas i [[localStorage och lagring|localStorage]].
+
+---
+
+## Rotationslogik
+
+### Hur det fungerar
+
+1. Vid sidladdning visas 9 slumpmässiga bilder
+2. Resterande bilder läggs i en "kö"
+3. Var 5:e sekund:
+   - En slumpmässig position (1-9) väljs
+   - En bild från kön plockas
+   - Bilden på vald position byts ut
+   - Den gamla bilden läggs tillbaka i kön
+
+### Kod
+
+```javascript
+function rotateRandomImage() {
+    // Välj slumpmässig position (0-8)
+    const randomIndex = Math.floor(Math.random() * imageElements.length);
+    const imgElement = imageElements[randomIndex];
+    
+    // Välj nästa bild från kön
+    if (imageStack.length > 0) {
+        const newImage = imageStack.pop();
+        const oldImage = imgElement.src;
+        
+        // Animera byte
+        imgElement.style.opacity = '0';
+        setTimeout(() => {
+            imgElement.src = newImage;
+            imgElement.style.opacity = '1';
+        }, 500);
+        
+        // Lägg tillbaka gamla bilden i kön
+        imageStack.unshift(oldImage);
+    }
+}
+
+// Starta rotation
+setInterval(rotateRandomImage, 5000);
+```
+
+---
+
+## Bildmetadata
+
+För vissa bilder finns metadata (tweet-URL, datum, text):
+
+```javascript
+const imageMetadata = {
+    'GziGQg-WUAAq9GH': {
+        url: 'https://x.com/kentlundgren/status/1961465270280577380',
+        date: '2025-04-17',
+        text: 'Bjerreds Saltsjöbad en vacker dag'
+    },
+    // ... fler bilder
+};
+```
+
+### Hur metadata används
+
+1. **Tooltip vid hover** - Visar datum om det finns
+2. **Lightbox** - Visar "Öppna på X"-knapp som länkar till original-tweet
+
+---
+
+## Bildlistor (UI)
+
+Applikationen visar tre listor för användaren:
+
+| Lista | Färg | Innehåll |
+|-------|------|----------|
+| 🖼️ Visas nu | Grön | De 9 bilder som visas just nu |
+| 📚 I kö | Blå | Bilder som väntar på att visas |
+| 👤 Dina bilder | Lila | Bilder användaren lagt till |
+
+---
+
+## CSS Grid-layout
+
+Collaget använder CSS Grid:
+
+```css
+.image-grid {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 15px;
+    max-width: 900px;
+    margin: 0 auto;
+}
+
+.image-grid img {
+    width: 100%;
+    aspect-ratio: 4/3;
+    object-fit: cover;
+    border-radius: 8px;
+    transition: opacity 0.5s ease;
+}
+```
+
+---
+
+## Relaterade sidor
+
+- [[Lightbox funktionalitet]] - Fullskärmsvisning
+- [[localStorage och lagring]] - Hur användarbilder sparas
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [MDN: CSS Grid Layout](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Grid_Layout) - Grid-referens
+- [MDN: setInterval](https://developer.mozilla.org/en-US/docs/Web/API/setInterval) - Timer-funktionen
+- [CSS-Tricks: A Complete Guide to Grid](https://css-tricks.com/snippets/css/complete-guide-grid/) - Grid-guide
+

--- a/wiki/Git-Grunderna.md
+++ b/wiki/Git-Grunderna.md
@@ -1,0 +1,198 @@
+# 🔧 Git Grunderna
+
+Denna sida ger en introduktion till **Git** - ett versionshanteringssystem som spårar ändringar i kod och möjliggör samarbete.
+
+---
+
+## Vad är Git?
+
+**Git** är ett distribuerat versionshanteringssystem (VCS) skapat av Linus Torvalds 2005. Det låter dig:
+
+- 📜 **Spåra ändringar** - Se vem som ändrade vad och när
+- ↩️ **Ångra misstag** - Återgå till tidigare versioner
+- 🌿 **Arbeta parallellt** - Utveckla features i separata branches
+- 👥 **Samarbeta** - Flera personer kan arbeta på samma projekt
+
+---
+
+## Git's fyra områden
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│                                                                         │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌───────────┐│
+│  │  Working    │───►│   Staging   │───►│    Local    │───►│  Remote   ││
+│  │  Directory  │    │    Area     │    │ Repository  │    │ (GitHub)  ││
+│  └─────────────┘    └─────────────┘    └─────────────┘    └───────────┘│
+│        │                  │                  │                  │      │
+│    Dina filer         git add           git commit          git push   │
+│                                                                         │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+| Område | Beskrivning |
+|--------|-------------|
+| **Working Directory** | Dina lokala filer (det du ser i mappen) |
+| **Staging Area** | Filer som ska ingå i nästa commit |
+| **Local Repository** | Din lokala Git-historik (.git-mappen) |
+| **Remote Repository** | GitHub, GitLab, Bitbucket etc. |
+
+---
+
+## Grundläggande kommandon
+
+### Första gången
+
+```bash
+# Konfigurera Git med ditt namn och e-post
+git config --global user.name "Ditt Namn"
+git config --global user.email "din@email.se"
+```
+
+### Dagligt arbetsflöde
+
+```bash
+# 1. Kolla status - vilka filer har ändrats?
+git status
+
+# 2. Lägg till filer till staging
+git add .                    # Alla filer
+git add filnamn.js           # En specifik fil
+
+# 3. Commita (spara) ändringarna
+git commit -m "Beskrivning av ändringen"
+
+# 4. Skicka till GitHub
+git push origin main
+```
+
+### Hämta ändringar
+
+```bash
+# Hämta och applicera ändringar från GitHub
+git pull origin main
+
+# Eller i två steg:
+git fetch origin        # Hämta info om ändringar
+git merge origin/main   # Applicera dem
+```
+
+---
+
+## git clone vs git pull
+
+### git clone
+Skapar en **ny kopia** av ett helt repository:
+
+```bash
+# Första gången - ladda ner projektet
+git clone https://github.com/lundgren9/Twitter.git
+```
+
+- ✅ Används första gången
+- ✅ Skapar ny mapp med alla filer
+- ✅ Sätter upp remote-koppling automatiskt
+
+### git pull
+Uppdaterar ett **befintligt** lokalt repository:
+
+```bash
+# Uppdatera befintligt projekt
+git pull origin main
+```
+
+- ✅ Används när du redan har projektet
+- ✅ Hämtar endast nya ändringar
+- ⚠️ Kräver att du redan klonat
+
+---
+
+## Visa information
+
+```bash
+# Se commit-historik
+git log --oneline
+
+# Se ändringar som inte är stagade
+git diff
+
+# Se vilka branches som finns
+git branch -a
+
+# Se vilken branch du är på
+git branch
+```
+
+---
+
+## Ångra ändringar
+
+```bash
+# Ångra ändringar i en fil (ej stagad)
+git restore filnamn.js
+
+# Ta bort fil från staging
+git restore --staged filnamn.js
+
+# Ångra senaste commit (behåll ändringar)
+git reset --soft HEAD~1
+
+# Ångra senaste commit (radera ändringar)
+git reset --hard HEAD~1
+```
+
+---
+
+## .gitignore
+
+Filen `.gitignore` talar om för Git vilka filer som **inte** ska spåras:
+
+```gitignore
+# Beroenden
+node_modules/
+vendor/
+
+# Byggda filer
+dist/
+build/
+
+# Miljövariabler (hemligheter!)
+.env
+.env.local
+
+# OS-filer
+.DS_Store
+Thumbs.db
+
+# IDE-inställningar
+.vscode/
+.idea/
+```
+
+---
+
+## Relaterade sidor
+
+- [[Arbetsflöde med branches]] - Feature Branch Workflow
+- [[Tags och Releases]] - Versionsmarkörer
+- [[GitHub Pages]] - Publicera webbsidor
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+### Officiell dokumentation
+- [Pro Git Book](https://git-scm.com/book/en/v2) - Gratis bok av Scott Chacon och Ben Straub
+- [Git Reference](https://git-scm.com/docs) - Kommandoreferens
+
+### Tutorials
+- [GitHub Skills](https://skills.github.com/) - Interaktiva kurser
+- [Learn Git Branching](https://learngitbranching.js.org/) - Visuell interaktiv tutorial
+- [Atlassian Git Tutorial](https://www.atlassian.com/git/tutorials) - Omfattande guider
+
+### Videos
+- [How Git Works: Explained in 4 Minutes](https://www.youtube.com/watch?v=e9lnsKot_SQ) - ByteByteGo
+- [Git and GitHub Tutorial for Beginners](https://youtu.be/tRZGeaHPoaw) - Kevin Stratvert
+- [Git Tutorial For Dummies](https://www.youtube.com/watch?v=mJ-qvsxPHpY) - Nick White
+

--- a/wiki/GitHub-Pages.md
+++ b/wiki/GitHub-Pages.md
@@ -1,0 +1,180 @@
+# 🌐 GitHub Pages
+
+Denna sida förklarar hur **GitHub Pages** fungerar och hur du kan använda det för att publicera webbsidor gratis.
+
+---
+
+## Vad är GitHub Pages?
+
+**GitHub Pages** är en gratis hosting-tjänst från GitHub som publicerar statiska webbsidor direkt från ett repository.
+
+### Perfekt för:
+- 📄 Dokumentation och README-filer
+- 🎨 Portfolios och personliga sidor
+- 🚀 Demo-sidor för projekt
+- 📝 Bloggar (med Jekyll)
+
+---
+
+## Hur aktivera GitHub Pages?
+
+1. Gå till ditt repository på GitHub
+2. Klicka **Settings**
+3. Scrolla ner till **Pages** i sidomenyn
+4. Under **Source**, välj branch (`main`) och mapp (`/ (root)`)
+5. Klicka **Save**
+
+Din sida blir tillgänglig på:
+```
+https://{användarnamn}.github.io/{repository-namn}/
+```
+
+**Exempel för detta projekt:**
+```
+https://lundgren9.github.io/Twitter/
+```
+
+---
+
+## URL-struktur
+
+GitHub Pages serverar alla filer i branchen som webbsidor:
+
+| Fil i repository | URL |
+|------------------|-----|
+| `index.html` | `lundgren9.github.io/Twitter/` |
+| `versioner.html` | `lundgren9.github.io/Twitter/versioner.html` |
+| `v2.0/index.html` | `lundgren9.github.io/Twitter/v2.0/` |
+| `wiki/Home.md` | `lundgren9.github.io/Twitter/wiki/Home.md` |
+
+### Undermappar för äldre versioner
+
+Du kan skapa separata mappar för varje version:
+
+```
+repository/
+├── index.html          → /
+├── styles.css
+├── javaScript.js
+├── versioner.html      → /versioner.html
+├── v1.0/
+│   ├── index.html      → /v1.0/
+│   ├── styles.css
+│   └── javaScript.js
+├── v2.0/
+│   └── ...             → /v2.0/
+└── v2.2/
+    └── ...             → /v2.2/
+```
+
+---
+
+## Begränsningar
+
+| Egenskap | Gräns |
+|----------|-------|
+| **Repository-storlek** | 1 GB rekommenderat |
+| **Bandbredd** | 100 GB/månad |
+| **Byggtid** | 10 minuter max |
+| **Filtyper** | Endast statiska filer |
+
+### Vad stöds INTE?
+
+❌ Server-side kod (PHP, Python, Node.js)
+❌ Databaser
+❌ Dynamiska API:er
+❌ Användarautentisering (inbyggd)
+
+---
+
+## GitHub Pages vs Webbhotell
+
+| Egenskap | GitHub Pages | Webbhotell |
+|----------|--------------|------------|
+| Kostnad | ✅ Gratis | 💰 ~50-200 kr/mån |
+| Statiska filer | ✅ Ja | ✅ Ja |
+| Server-side | ❌ Nej | ✅ Ja |
+| Databas | ❌ Nej | ✅ Ja |
+| HTTPS | ✅ Automatiskt | ⚠️ Ibland extra |
+| Custom domän | ✅ Ja | ✅ Ja |
+| Versionskontroll | ✅ Inbyggt | ❌ Manuellt |
+
+---
+
+## Custom domän
+
+Du kan använda egen domän istället för `github.io`:
+
+1. Köp domän (t.ex. `minapp.se`)
+2. Lägg till en `CNAME`-fil i repositoryt:
+   ```
+   minapp.se
+   ```
+3. Konfigurera DNS hos din domänleverantör:
+   ```
+   CNAME  www   lundgren9.github.io
+   A      @     185.199.108.153
+   A      @     185.199.109.153
+   A      @     185.199.110.153
+   A      @     185.199.111.153
+   ```
+
+---
+
+## Jekyll (valfritt)
+
+GitHub Pages stöder **Jekyll** för att bygga webbsidor från Markdown:
+
+```yaml
+# _config.yml
+title: Min Sida
+theme: minima
+```
+
+```markdown
+---
+layout: post
+title: "Min första post"
+---
+
+Här är mitt innehåll...
+```
+
+---
+
+## Felsökning
+
+### Sidan uppdateras inte
+
+1. Vänta några minuter (cache)
+2. Kolla **Settings → Pages** för bygstatus
+3. Töm webbläsarens cache (Ctrl+Shift+R)
+
+### 404-fel
+
+- Kontrollera att filen finns i rätt branch
+- Kontrollera filnamnet (skiftlägeskänsligt!)
+- `index.html` krävs för `/`-URL
+
+### Sidan är tom
+
+- Kontrollera att `index.html` har innehåll
+- Kolla konsolen (F12) för JavaScript-fel
+
+---
+
+## Relaterade sidor
+
+- [[Git Grunderna]] - Introduktion till Git
+- [[Tags och Releases]] - Versionshantering
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [GitHub Pages Documentation](https://docs.github.com/en/pages) - Officiell dokumentation
+- [GitHub Pages Quickstart](https://docs.github.com/en/pages/quickstart) - Kom igång-guide
+- [Custom domains](https://docs.github.com/en/pages/configuring-a-custom-domain-for-your-github-pages-site) - Egen domän
+- [Jekyll Documentation](https://jekyllrb.com/docs/) - Jekyll-guide
+

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,102 @@
+# 🏠 Bjerreds Saltsjöbad - Bildcollage
+
+Välkommen till dokumentationen för **Bjerreds Saltsjöbad Bildcollage** - en webbaserad applikation som visar ett roterande collage av bilder från Twitter/X med hashtag [#Bjerredssaltsjobad](https://x.com/search?q=%23Bjerredssaltsjobad).
+
+## 🔗 Snabblänkar
+
+| Resurs | Beskrivning |
+|--------|-------------|
+| [🌐 Live Demo](https://lundgren9.github.io/Twitter/) | Kör programmet i webbläsaren |
+| [📦 GitHub Repository](https://github.com/lundgren9/Twitter) | Källkod och releases |
+| [📋 Releases](https://github.com/lundgren9/Twitter/releases) | Alla versioner |
+| [📚 Versionshistorik](https://lundgren9.github.io/Twitter/versioner.html) | Git-guide och äldre versioner |
+
+---
+
+## 📖 Wiki-sidor
+
+### Programfunktionalitet
+- [[Bildhantering]] - Hur bildcollaget och rotationen fungerar
+- [[localStorage och lagring]] - Hur data sparas utan backend
+- [[X API och Twitter]] - Hämta bilder från Twitter/X
+- [[Lightbox funktionalitet]] - Fullskärmsvisning av bilder
+
+### Git och GitHub
+- [[Git Grunderna]] - Introduktion till versionshantering
+- [[Arbetsflöde med branches]] - Feature Branch Workflow
+- [[Tags och Releases]] - Versionshantering med Git tags
+- [[GitHub Pages]] - Publicera webbsidor gratis
+
+---
+
+## 🛠️ Teknisk översikt
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                     ANVÄNDARE (Webbläsare)                  │
+├─────────────────────────────────────────────────────────────┤
+│  index.html  │  styles.css  │  javaScript.js                │
+├──────────────┼──────────────┼────────────────────────────────┤
+│   HTML5      │   CSS3       │   JavaScript ES6+              │
+│   Semantik   │   Grid       │   localStorage                 │
+│   Video      │   Flexbox    │   DOM manipulation             │
+│   Lightbox   │   Animation  │   Async/Await                  │
+├─────────────────────────────────────────────────────────────┤
+│                     GitHub Pages (hosting)                   │
+├─────────────────────────────────────────────────────────────┤
+│                     GitHub API (version info)                │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🎯 Funktioner
+
+| Funktion | Beskrivning |
+|----------|-------------|
+| 🖼️ Bildcollage | 9 bilder som roterar var 5:e sekund |
+| 🔍 Lightbox | Klicka på bild för fullskärmsvisning |
+| ➕ Lägg till bilder | Input-fält för egna bild-URLs |
+| 💾 localStorage | Sparar dina bilder lokalt |
+| 🎬 Twitter-video | Inbäddad video via oEmbed |
+| 🏷️ Versionsbadge | Visar version från GitHub API |
+
+---
+
+## 📚 Externa resurser
+
+### Relaterade Wikis och guider
+
+| Resurs | Beskrivning |
+|--------|-------------|
+| [Git Book (Pro Git)](https://git-scm.com/book/en/v2) | Officiell Git-dokumentation |
+| [GitHub Docs](https://docs.github.com) | GitHub's officiella dokumentation |
+| [MDN Web Docs - localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) | localStorage API-referens |
+| [Twitter API Documentation](https://developer.twitter.com/en/docs) | X/Twitter API-dokumentation |
+| [GitHub Pages Docs](https://docs.github.com/en/pages) | Hur GitHub Pages fungerar |
+
+### Videoresurser
+
+- [How Git Works: Explained in 4 Minutes](https://www.youtube.com/watch?v=e9lnsKot_SQ) - ByteByteGo
+- [Git and GitHub Tutorial for Beginners](https://youtu.be/tRZGeaHPoaw) - Kevin Stratvert
+- [Git Tutorial For Dummies](https://www.youtube.com/watch?v=mJ-qvsxPHpY) - Nick White
+
+---
+
+## 🔄 Versioner
+
+| Version | Datum | Nyheter |
+|---------|-------|---------|
+| [v2.4](https://github.com/lundgren9/Twitter/releases/tag/v2.4) | 2026-01-04 | Versionshistorik, Git-guide, Wiki |
+| [v2.2](https://github.com/lundgren9/Twitter/releases/tag/v2.2) | 2026-01-04 | Versionsbadge, GitHub API |
+| [v2.0](https://github.com/lundgren9/Twitter/releases/tag/v2.0) | 2026-01-04 | Lightbox, 16 bilder |
+| [v1.0](https://github.com/lundgren9/Twitter/releases/tag/Release) | 2026-01-03 | Första release |
+
+---
+
+## 👤 Kontakt
+
+**Kent Lundgren**  
+🌐 [kentlundgren.se](https://www.kentlundgren.se)  
+🐦 [@kentlundgren](https://x.com/kentlundgren)
+

--- a/wiki/Lightbox-funktionalitet.md
+++ b/wiki/Lightbox-funktionalitet.md
@@ -1,0 +1,260 @@
+# 🔍 Lightbox funktionalitet
+
+Denna sida förklarar hur **Lightbox** (fullskärmsvisning av bilder) fungerar i applikationen.
+
+---
+
+## Vad är en Lightbox?
+
+En **Lightbox** är ett användargränssnittsmönster som visar en bild i fullskärm med en mörk bakgrund ("overlay"). Användaren kan sedan stänga visningen genom att klicka på X eller bakgrunden.
+
+```
+┌────────────────────────────────────────────┐
+│                                            │
+│   ┌────────────────────────────────────┐   │
+│   │                                    │   │
+│   │                                    │   │
+│   │          BILD I FULLSKÄRM          │   │
+│   │                                    │   │
+│   │                                    │   │
+│   └────────────────────────────────────┘   │
+│                                            │
+│        [Öppna på X]    [✕ Stäng]           │
+│                                            │
+└────────────────────────────────────────────┘
+      ↑ Mörk semitransparent bakgrund
+```
+
+---
+
+## HTML-struktur
+
+```html
+<!-- Lightbox container (dold som standard) -->
+<div id="imageLightbox" class="lightbox">
+    <div class="lightbox-content">
+        <!-- Stäng-knapp -->
+        <button class="lightbox-close" aria-label="Stäng">✕</button>
+        
+        <!-- Bilden -->
+        <img id="lightboxImage" src="" alt="Förstorad bild">
+        
+        <!-- Knappar -->
+        <div class="lightbox-buttons">
+            <a id="openOnTwitter" href="#" target="_blank">
+                🐦 Öppna på X
+            </a>
+        </div>
+    </div>
+</div>
+```
+
+---
+
+## CSS-styling
+
+```css
+/* Overlay - täcker hela skärmen */
+.lightbox {
+    display: none;                    /* Dold som standard */
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    background: rgba(0, 0, 0, 0.9);   /* Mörk bakgrund */
+    z-index: 2000;                    /* Ovanpå allt annat */
+    justify-content: center;
+    align-items: center;
+}
+
+/* Visa lightbox */
+.lightbox.active {
+    display: flex;
+}
+
+/* Bilden */
+.lightbox-content img {
+    max-width: 90vw;      /* Max 90% av skärmbredd */
+    max-height: 80vh;     /* Max 80% av skärmhöjd */
+    object-fit: contain;  /* Behåll proportioner */
+    border-radius: 8px;
+}
+
+/* Stäng-knapp */
+.lightbox-close {
+    position: absolute;
+    top: 20px;
+    right: 20px;
+    font-size: 2rem;
+    color: white;
+    background: none;
+    border: none;
+    cursor: pointer;
+}
+
+/* Animation vid öppning */
+.lightbox-content {
+    animation: zoomIn 0.3s ease;
+}
+
+@keyframes zoomIn {
+    from {
+        transform: scale(0.8);
+        opacity: 0;
+    }
+    to {
+        transform: scale(1);
+        opacity: 1;
+    }
+}
+```
+
+---
+
+## JavaScript-logik
+
+### Setup
+
+```javascript
+function setupLightbox() {
+    const lightbox = document.getElementById('imageLightbox');
+    const lightboxImage = document.getElementById('lightboxImage');
+    const closeButton = document.querySelector('.lightbox-close');
+    const openOnTwitter = document.getElementById('openOnTwitter');
+    
+    // Klick på bild → öppna lightbox
+    document.querySelectorAll('.image-grid img').forEach(img => {
+        img.addEventListener('click', () => openLightbox(img.src));
+        img.style.cursor = 'pointer';
+    });
+    
+    // Stäng-knapp
+    closeButton.addEventListener('click', closeLightbox);
+    
+    // Klick på bakgrund → stäng
+    lightbox.addEventListener('click', (e) => {
+        if (e.target === lightbox) closeLightbox();
+    });
+    
+    // ESC-tangent → stäng
+    document.addEventListener('keydown', (e) => {
+        if (e.key === 'Escape') closeLightbox();
+    });
+}
+```
+
+### Öppna lightbox
+
+```javascript
+function openLightbox(imageSrc) {
+    const lightbox = document.getElementById('imageLightbox');
+    const lightboxImage = document.getElementById('lightboxImage');
+    const openOnTwitter = document.getElementById('openOnTwitter');
+    
+    // Sätt bilden
+    lightboxImage.src = imageSrc;
+    
+    // Hämta metadata (tweet-URL)
+    const imageId = extractImageId(imageSrc);
+    const metadata = imageMetadata[imageId];
+    
+    if (metadata && metadata.url) {
+        openOnTwitter.href = metadata.url;
+        openOnTwitter.style.display = 'inline-flex';
+    } else {
+        // Fallback till användarens profil
+        openOnTwitter.href = 'https://x.com/kentlundgren';
+    }
+    
+    // Visa lightbox
+    lightbox.classList.add('active');
+    
+    // Förhindra scrollning på body
+    document.body.style.overflow = 'hidden';
+}
+```
+
+### Stäng lightbox
+
+```javascript
+function closeLightbox() {
+    const lightbox = document.getElementById('imageLightbox');
+    
+    lightbox.classList.remove('active');
+    
+    // Återställ scrollning
+    document.body.style.overflow = '';
+}
+```
+
+---
+
+## Bildmetadata
+
+För att "Öppna på X"-knappen ska länka till rätt tweet lagras metadata:
+
+```javascript
+const imageMetadata = {
+    // Nyckel = del av bild-URL
+    'GziGQg-WUAAq9GH': {
+        url: 'https://x.com/kentlundgren/status/1961465270280577380',
+        date: '2025-04-17',
+        text: 'Bjerreds Saltsjöbad en vacker dag'
+    },
+    'G9gcau5WAAAs3nw': {
+        url: 'https://x.com/kentlundgren/status/...',
+        date: '2025-05-20',
+        text: 'Sommar vid havet'
+    }
+    // ... fler bilder
+};
+
+// Extrahera ID från URL
+function extractImageId(url) {
+    const match = url.match(/media\/([A-Za-z0-9_-]+)/);
+    return match ? match[1] : null;
+}
+```
+
+---
+
+## Accessibility
+
+### Keyboard navigation
+- **ESC** - Stäng lightbox
+- **Tab** - Navigera mellan knappar
+
+### ARIA-attribut
+```html
+<button class="lightbox-close" aria-label="Stäng bildvisning">✕</button>
+<div role="dialog" aria-modal="true" aria-label="Bildvisning">
+```
+
+### Focus trap
+När lightbox är öppen bör fokus stanna inom den:
+```javascript
+// Förhindra tab utanför lightbox
+lightbox.addEventListener('keydown', (e) => {
+    if (e.key === 'Tab') {
+        // Håll fokus inom lightbox
+    }
+});
+```
+
+---
+
+## Relaterade sidor
+
+- [[Bildhantering]] - Bildrotation och collage
+- [[localStorage och lagring]] - Spara användarbilder
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [MDN: Dialog element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/dialog) - Native dialog-element
+- [WAI-ARIA: Modal Dialog](https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/) - Accessibility-guide
+- [CSS-Tricks: Lightbox](https://css-tricks.com/creating-a-modal-image-gallery-with-bootstrap-components/) - Tutorial
+

--- a/wiki/Tags-och-Releases.md
+++ b/wiki/Tags-och-Releases.md
@@ -1,0 +1,222 @@
+# 🏷️ Tags och Releases
+
+Denna sida förklarar hur man använder **Git tags** och **GitHub Releases** för versionshantering.
+
+---
+
+## Vad är en tag?
+
+En **tag** är en permanent referens till en specifik commit. Till skillnad från branches (som flyttas vid varje commit) pekar en tag **alltid på samma commit**.
+
+```
+       v1.0          v2.0           v2.4
+         │             │              │
+         ▼             ▼              ▼
+main ────●─────●───────●──────●───────●─────►
+```
+
+---
+
+## Lightweight vs Annotated tags
+
+| Typ | Kommando | Innehåll |
+|-----|----------|----------|
+| **Lightweight** | `git tag v1.0` | Bara en pekare till commit |
+| **Annotated** ✅ | `git tag -a v1.0 -m "..."` | Författare, datum, meddelande, GPG-signatur |
+
+### Rekommendation: Använd alltid annoterade tags
+
+```bash
+git tag -a v2.5 -m "Version 2.5: Ny feature X och buggfix Y"
+```
+
+---
+
+## Skapa och hantera tags
+
+### Skapa tag lokalt
+
+```bash
+# Skapa annoterad tag
+git tag -a v2.5 -m "Version 2.5: Beskrivning av versionen"
+
+# Verifiera att taggen skapades
+git tag
+# Output: v1.0, v2.0, v2.2, v2.4, v2.5
+```
+
+### Pusha tag till GitHub
+
+```bash
+# Pusha specifik tag
+git push origin v2.5
+
+# Pusha ALLA tags
+git push origin --tags
+```
+
+### Visa tag-information
+
+```bash
+# Lista alla tags
+git tag
+
+# Visa info om specifik tag
+git show v2.5
+```
+
+### Ta bort tag
+
+```bash
+# Ta bort lokalt
+git tag -d v2.5-beta
+
+# Ta bort från GitHub
+git push origin --delete v2.5-beta
+```
+
+---
+
+## Skapa tag på GitHub först
+
+Du kan också skapa en tag direkt på GitHub:
+
+1. Gå till **Releases → Create a new release**
+2. Skriv in nytt tag-namn (t.ex. `v2.5`)
+3. GitHub skapar automatiskt taggen när du publicerar
+
+**Synka lokalt:**
+```bash
+git fetch --tags
+```
+
+---
+
+## git show - Visa historisk version
+
+`git show` visar innehållet i Git-objekt:
+
+```bash
+# Visa hur en fil såg ut i v2.0
+git show v2.0:index.html
+
+# Spara filen lokalt (PowerShell, med UTF-8!)
+git show v2.0:index.html | Out-File -Encoding utf8 -FilePath v2.0/index.html
+
+# Visa senaste commit
+git show HEAD
+
+# Visa en specifik commit
+git show abc1234
+```
+
+---
+
+## GitHub Releases
+
+En **Release** är en GitHub-feature som bygger på tags och lägger till:
+
+- 📝 Formaterade release notes
+- 📦 Nedladdningsbara filer (Source code zip/tar)
+- 🔗 Delbar URL
+
+### Skapa Release
+
+1. Gå till `github.com/lundgren9/Twitter/releases/new`
+2. **Choose a tag:** Välj din tag (eller skapa ny)
+3. **Release title:** t.ex. "Version 2.5 - Ny Wiki"
+4. **Describe:** Skriv release notes
+5. **Publish release**
+
+### Exempel på Release Notes
+
+```markdown
+# Version 2.5 - Wiki och dokumentation
+
+## 🆕 Nyheter
+
+### 📚 GitHub Wiki
+- Komplett dokumentation för projektet
+- 8 sidor med tutorials och guider
+- Länkar till externa resurser
+
+### 🔧 Förbättringar
+- Uppdaterad versioner.html
+- Bättre förklaringar av Git-kommandon
+
+## 📖 Wiki-sidor
+- [Home](wiki/Home)
+- [Bildhantering](wiki/Bildhantering)
+- [localStorage](wiki/localStorage-och-lagring)
+- [Git Grunderna](wiki/Git-Grunderna)
+- ... och fler!
+
+## 📁 Ändrade filer
+- `wiki/` (ny mapp med 8 .md-filer)
+- `versioner.html`
+```
+
+---
+
+## Tag vs Branch
+
+| Egenskap | Tag | Branch |
+|----------|-----|--------|
+| **Flyttbar?** | ❌ Nej, pekar alltid på samma commit | ✅ Ja, flyttas vid varje commit |
+| **Syfte** | Markera specifika punkter (releases) | Aktiv utveckling |
+| **Skapas** | `git tag -a v1.0 -m "..."` | `git branch feature-x` |
+| **Pushas** | `git push origin v1.0` | `git push origin feature-x` |
+
+---
+
+## Tags för annat än versioner
+
+Tags kan användas för:
+
+| Användning | Exempel |
+|------------|---------|
+| **Releaseversioner** | `v1.0`, `v2.0`, `v3.0-beta` |
+| **Milstolpar** | `sprint-1-done`, `feature-complete` |
+| **Deployment** | `deployed-2026-01-04`, `prod-20260104` |
+| **Backup** | `before-refactor`, `pre-migration` |
+| **Review** | `code-review-1`, `audit-2026` |
+
+---
+
+## Semantisk versionering (SemVer)
+
+Rekommenderad namnkonvention:
+
+```
+v[MAJOR].[MINOR].[PATCH]
+
+Exempel: v2.5.1
+         │ │ └── PATCH: Buggfixar
+         │ └──── MINOR: Ny funktionalitet (bakåtkompatibel)
+         └────── MAJOR: Brytande ändringar
+```
+
+| Ändring | Exempel |
+|---------|---------|
+| v1.0.0 → v1.0.1 | Buggfix |
+| v1.0.1 → v1.1.0 | Ny feature |
+| v1.1.0 → v2.0.0 | API-ändring |
+
+Se: [semver.org](https://semver.org/)
+
+---
+
+## Relaterade sidor
+
+- [[Git Grunderna]] - Introduktion till Git
+- [[Arbetsflöde med branches]] - Feature Branch Workflow
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [Git Tagging](https://git-scm.com/book/en/v2/Git-Basics-Tagging) - Pro Git Book
+- [GitHub Releases](https://docs.github.com/en/repositories/releasing-projects-on-github) - Officiell dokumentation
+- [Semantic Versioning](https://semver.org/) - SemVer-specifikation
+

--- a/wiki/X-API-och-Twitter.md
+++ b/wiki/X-API-och-Twitter.md
@@ -1,0 +1,212 @@
+# 🐦 X API och Twitter
+
+Denna sida förklarar hur man kan hämta bilder automatiskt från Twitter/X, och varför det kräver en backend-lösning.
+
+---
+
+## Nuvarande implementation
+
+I nuvarande version används **hårdkodade bild-URLs** från Twitter:
+
+```javascript
+const defaultImages = [
+    'https://pbs.twimg.com/media/G6SRdvUW0AEJc6G?format=jpg&name=large',
+    // ... fler URLs
+];
+```
+
+**Fördelar:**
+- ✅ Gratis
+- ✅ Ingen API-nyckel krävs
+- ✅ Fungerar alltid
+
+**Nackdelar:**
+- ❌ Manuell uppdatering krävs
+- ❌ Inga nya bilder automatiskt
+
+---
+
+## Twitter/X API - Översikt
+
+### API-nivåer (2024)
+
+| Nivå | Kostnad | Tweets/månad | Sökning |
+|------|---------|--------------|---------|
+| **Free** | Gratis | 1,500 (endast skriva) | ❌ |
+| **Basic** | ~$100/mån | 10,000 | ✅ |
+| **Pro** | ~$5,000/mån | 1,000,000 | ✅ |
+
+> ⚠️ **Observera:** Free-nivån tillåter **inte** sökning efter tweets. Du måste ha minst Basic-nivån.
+
+---
+
+## Varför behövs en backend?
+
+### Problem 1: CORS (Cross-Origin Resource Sharing)
+
+Webbläsare blockerar direkta anrop till Twitter API:
+
+```
+┌─────────────────┐          ┌─────────────────┐
+│   Webbläsare    │   ──X──► │   Twitter API   │
+│  (JavaScript)   │  BLOCKED │                 │
+└─────────────────┘          └─────────────────┘
+```
+
+**Lösning:** Använd en backend som mellanhand:
+
+```
+┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
+│   Webbläsare    │ ──► │   Din server    │ ──► │   Twitter API   │
+│  (JavaScript)   │     │   (Backend)     │     │                 │
+└─────────────────┘     └─────────────────┘     └─────────────────┘
+```
+
+### Problem 2: API-nyckel exponeras
+
+Om du anropar Twitter API direkt från JavaScript syns din API-nyckel i webbläsarens utvecklarverktyg. **Vem som helst kan stjäla den!**
+
+---
+
+## Implementation med backend
+
+### Steg 1: Skaffa API-nyckel
+
+1. Gå till [X Developer Portal](https://developer.twitter.com)
+2. Skapa ett konto och projekt
+3. Uppgradera till **Basic tier** (~$100/mån)
+4. Generera en **Bearer Token**
+
+### Steg 2: Skapa backend-proxy (PHP)
+
+```php
+<?php
+// twitter-proxy.php
+// Denna fil läggs på din server (t.ex. kentlundgren.se)
+
+header('Content-Type: application/json');
+header('Access-Control-Allow-Origin: *'); // Tillåt anrop från vilken domän som helst
+
+// VIKTIGT: Spara token säkert (miljövariabel eller config-fil utanför webroot)
+$bearer_token = getenv('TWITTER_BEARER_TOKEN');
+
+// Sökfråga
+$query = urlencode('#Bjerredssaltsjobad');
+
+// Twitter API v2 endpoint
+$url = "https://api.twitter.com/2/tweets/search/recent"
+     . "?query=$query"
+     . "&max_results=100"
+     . "&expansions=attachments.media_keys"
+     . "&media.fields=url,preview_image_url";
+
+// Gör anrop
+$ch = curl_init();
+curl_setopt($ch, CURLOPT_URL, $url);
+curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+curl_setopt($ch, CURLOPT_HTTPHEADER, [
+    "Authorization: Bearer $bearer_token"
+]);
+
+$response = curl_exec($ch);
+$httpCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+
+// Returnera svar
+http_response_code($httpCode);
+echo $response;
+?>
+```
+
+### Steg 3: Anropa från JavaScript
+
+```javascript
+async function fetchImagesFromTwitter() {
+    try {
+        // Anropa din backend-proxy
+        const response = await fetch('https://www.kentlundgren.se/twitter-proxy.php');
+        
+        if (!response.ok) {
+            throw new Error(`HTTP error: ${response.status}`);
+        }
+        
+        const data = await response.json();
+        
+        // Extrahera bild-URLs
+        const images = data.includes?.media
+            ?.filter(media => media.type === 'photo')
+            ?.map(media => media.url) || [];
+        
+        console.log(`Hämtade ${images.length} bilder från Twitter`);
+        return images;
+        
+    } catch (error) {
+        console.error('Kunde inte hämta bilder:', error);
+        return [];
+    }
+}
+```
+
+---
+
+## Twitter oEmbed (Video)
+
+För att bädda in en tweet eller video kan du använda **oEmbed** (gratis):
+
+```html
+<!-- I HTML -->
+<blockquote class="twitter-tweet">
+    <a href="https://twitter.com/kentlundgren/status/1991876902991343647"></a>
+</blockquote>
+
+<!-- Ladda Twitter's widget-script -->
+<script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+```
+
+### Ladda dynamiskt med JavaScript
+
+```javascript
+function loadTwitterWidget() {
+    return new Promise((resolve) => {
+        if (window.twttr) {
+            window.twttr.widgets.load();
+            resolve();
+        } else {
+            const script = document.createElement('script');
+            script.src = 'https://platform.twitter.com/widgets.js';
+            script.onload = resolve;
+            document.head.appendChild(script);
+        }
+    });
+}
+```
+
+---
+
+## Alternativ: Manuell bildkurering
+
+Om du inte vill betala för API:
+
+1. **Sök manuellt** på Twitter efter #Bjerredssaltsjobad
+2. **Högerklicka** på bilden → "Kopiera bildadress"
+3. **Klistra in** i applikationens input-fält
+4. **Spara** i [[localStorage och lagring|localStorage]]
+
+---
+
+## Relaterade sidor
+
+- [[localStorage och lagring]] - Lokal lagring av bilder
+- [[Bildhantering]] - Hur bilder visas
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [Twitter API v2 Documentation](https://developer.twitter.com/en/docs/twitter-api) - Officiell dokumentation
+- [Twitter Developer Portal](https://developer.twitter.com) - Skapa API-konto
+- [Twitter oEmbed](https://developer.twitter.com/en/docs/twitter-for-websites/oembed-api) - Bädda in tweets
+- [MDN: CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS) - Förstå CORS
+- [PHP cURL Documentation](https://www.php.net/manual/en/book.curl.php) - Backend-anrop
+

--- a/wiki/localStorage-och-lagring.md
+++ b/wiki/localStorage-och-lagring.md
@@ -1,0 +1,222 @@
+# 💾 localStorage och lagring
+
+Denna sida förklarar hur data lagras i webbläsaren **utan behov av en backend-server**.
+
+---
+
+## Vad är localStorage?
+
+**localStorage** är en inbyggd lagringsmekanism i alla moderna webbläsare. Det är en **key-value store** som sparar data permanent (tills användaren rensar webbläsardata).
+
+```
+┌─────────────────────────────────────────┐
+│           WEBBLÄSARE                    │
+│  ┌───────────────────────────────────┐  │
+│  │      localStorage                 │  │
+│  │  ┌─────────────┬───────────────┐  │  │
+│  │  │    KEY      │    VALUE      │  │  │
+│  │  ├─────────────┼───────────────┤  │  │
+│  │  │ user_images │ ["url1",...]  │  │  │
+│  │  │ settings    │ {"theme":...} │  │  │
+│  │  └─────────────┴───────────────┘  │  │
+│  └───────────────────────────────────┘  │
+└─────────────────────────────────────────┘
+```
+
+---
+
+## Egenskaper
+
+| Egenskap | Värde |
+|----------|-------|
+| **Kapacitet** | ~5-10 MB per domän |
+| **Livslängd** | Permanent (tills användaren rensar) |
+| **Tillgänglighet** | Endast samma webbläsare/enhet |
+| **Säkerhet** | Isolerad per domän (same-origin policy) |
+| **Datatyp** | Endast strängar (JSON.stringify för objekt) |
+
+---
+
+## Hur vi använder det
+
+### Spara bilder
+
+```javascript
+function saveUserImages(images) {
+    // Konvertera array till JSON-sträng
+    const jsonString = JSON.stringify(images);
+    
+    // Spara i localStorage
+    localStorage.setItem('bjerred_user_images', jsonString);
+    
+    console.log(`Sparade ${images.length} bilder`);
+}
+```
+
+### Hämta bilder
+
+```javascript
+function loadSavedImages() {
+    // Hämta från localStorage
+    const saved = localStorage.getItem('bjerred_user_images');
+    
+    // Om inget finns, returnera tom array
+    if (!saved) return [];
+    
+    // Konvertera JSON-sträng till array
+    return JSON.parse(saved);
+}
+```
+
+### Radera bilder
+
+```javascript
+function clearUserImages() {
+    localStorage.removeItem('bjerred_user_images');
+    console.log('Alla användarbilder raderade');
+}
+```
+
+---
+
+## Fullständigt exempel
+
+```javascript
+// ========================================
+// BILDHANTERING MED LOCALSTORAGE
+// ========================================
+
+const STORAGE_KEY = 'bjerred_user_images';
+
+// SPARA
+function saveUserImages(images) {
+    try {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(images));
+        return true;
+    } catch (e) {
+        console.error('Kunde inte spara:', e);
+        return false;
+    }
+}
+
+// HÄMTA
+function loadSavedImages() {
+    try {
+        const saved = localStorage.getItem(STORAGE_KEY);
+        return saved ? JSON.parse(saved) : [];
+    } catch (e) {
+        console.error('Kunde inte läsa:', e);
+        return [];
+    }
+}
+
+// LÄGG TILL EN BILD
+function addUserImage(imageUrl) {
+    const images = loadSavedImages();
+    
+    // Kontrollera om bilden redan finns
+    if (images.includes(imageUrl)) {
+        console.warn('Bilden finns redan');
+        return false;
+    }
+    
+    images.push(imageUrl);
+    return saveUserImages(images);
+}
+
+// TA BORT EN BILD
+function removeUserImage(imageUrl) {
+    const images = loadSavedImages();
+    const filtered = images.filter(img => img !== imageUrl);
+    return saveUserImages(filtered);
+}
+
+// RENSA ALLT
+function clearAllImages() {
+    localStorage.removeItem(STORAGE_KEY);
+}
+```
+
+---
+
+## Fördelar och nackdelar
+
+### ✅ Fördelar
+
+| Fördel | Förklaring |
+|--------|------------|
+| Ingen backend | Allt körs i webbläsaren |
+| Gratis | Ingen server att betala för |
+| Snabbt | Ingen nätverksfördröjning |
+| Enkelt | Bara några rader JavaScript |
+| Persistent | Data överlever sidladdningar |
+
+### ⚠️ Nackdelar
+
+| Nackdel | Förklaring |
+|---------|------------|
+| Endast lokal | Data finns bara i en webbläsare |
+| Kan rensas | Försvinner om användaren rensar data |
+| Ingen synk | Olika enheter = olika data |
+| Storleksgräns | Max ~5-10 MB |
+| Endast strängar | Måste konvertera objekt med JSON |
+
+---
+
+## När behövs en backend?
+
+localStorage räcker inte om du behöver:
+
+| Behov | Lösning |
+|-------|---------|
+| Dela data mellan användare | Backend + databas |
+| Synka mellan enheter | Backend + autentisering |
+| Stora datamängder | Backend + fillagring |
+| Säkra API-anrop | Backend-proxy |
+| Avancerad sökning | Backend + sökmotor |
+
+---
+
+## Alternativ till localStorage
+
+| Lagringstyp | Kapacitet | Livslängd | Användning |
+|-------------|-----------|-----------|------------|
+| **localStorage** | 5-10 MB | Permanent | Användarpreferenser |
+| **sessionStorage** | 5-10 MB | Tills flik stängs | Tillfällig data |
+| **IndexedDB** | Stort (GB) | Permanent | Stora datamängder |
+| **Cookies** | 4 KB | Konfigurerbar | Autentisering |
+
+---
+
+## Debug-kommandon
+
+Öppna webbläsarens konsol (F12) och testa:
+
+```javascript
+// Se allt i localStorage
+console.log(localStorage);
+
+// Se sparade bilder
+console.log(JSON.parse(localStorage.getItem('bjerred_user_images')));
+
+// Rensa allt
+localStorage.clear();
+```
+
+---
+
+## Relaterade sidor
+
+- [[Bildhantering]] - Hur bilder visas och roteras
+- [[X API och Twitter]] - Backend-lösning för API
+- [[Home]] - Tillbaka till startsidan
+
+---
+
+## Externa resurser
+
+- [MDN: Window.localStorage](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage) - Officiell dokumentation
+- [MDN: Web Storage API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Storage_API) - Översikt
+- [javascript.info: LocalStorage](https://javascript.info/localstorage) - Tutorial
+- [Can I use: localStorage](https://caniuse.com/namevalue-storage) - Webbläsarstöd
+


### PR DESCRIPTION
## 📚 Version 2.5 - GitHub Wiki

### Nyheter
Skapar 9 wiki-sidor med komplett dokumentation för projektet.

### Wiki-sidor
- **Home** - Startsida med översikt
- **Bildhantering** - Hur collaget fungerar
- **localStorage** - Lagring utan backend
- **X API och Twitter** - API-dokumentation
- **Git Grunderna** - Introduktion
- **Arbetsflöde med branches** - Feature Branch Workflow
- **Tags och Releases** - Versionshantering
- **GitHub Pages** - Publicering
- **Lightbox** - Fullskärmsvisning

### Externa resurser refererade
- [Pro Git Book](https://git-scm.com/book/en/v2)
- [GitHub Docs](https://docs.github.com)
- [MDN Web Docs](https://developer.mozilla.org)
- ByteByteGo videos